### PR TITLE
resolve window icon at runtime and build time

### DIFF
--- a/.electron-builder.js
+++ b/.electron-builder.js
@@ -1,4 +1,5 @@
 const { name, productName, appId, version } = require('./package.json');
+const icon = require('./lib/icon.js')('build');
 
 const fileName = productName.replace(/\s/g, '');
 
@@ -12,10 +13,10 @@ module.exports = {
     '!.*'
   ],
   mac: {
+    icon,
     target: [
       'dmg'
     ],
-    icon: 'icons/icon.icns',
     darkModeSupport: true
   },
   dmg: {
@@ -23,11 +24,11 @@ module.exports = {
     artifactName: `${fileName}-v\${version}-MacOS-setup.\${ext}`
   },
   win: {
+    icon,
     target: [
       'nsis',
       'portable'
-    ],
-    icon: 'icons/icon.ico'
+    ]
   },
   nsis: {
     artifactName: `${fileName}-v\${version}-Windows-setup.\${ext}`
@@ -36,7 +37,7 @@ module.exports = {
     artifactName: `${fileName}-v\${version}-Windows-portable.\${ext}`
   },
   linux: {
-    icon: 'icons/256x256.png',
+    icon,
     target: [
       'AppImage'
     ],

--- a/lib/icon.js
+++ b/lib/icon.js
@@ -1,35 +1,30 @@
 const path = require('path');
 const is = require('./is.js');
 
-const osMap = {
-  win32: 'win',
-  darwin: 'mac',
-  linux: 'linux'
-};
-
 const iconMap = {
-  win: 'icons/icon.ico',
-  linux: 'icons/32x32.png',
-  mac: 'icons/icon.icns'
+  'win32-runtime': 'icons/icon.ico',
+  'linux-runtime': 'icons/32x32.png',
+  'linux-build': 'icons/256x256.png',
+  'darwin-runtime': 'icons/icon.icns'
 };
 
-module.exports = () => {
-  const os = osMap[process.platform];
-  let icon = os ? path.resolve(__dirname, '..', iconMap[os]) : undefined;
+module.exports = (type = 'runtime') => {
+  const iconName = iconMap[`${process.platform}-${type}`] || iconMap[`${process.platform}-runtime`];
+  let icon = iconName ? path.resolve(__dirname, '..', iconName) : undefined;
 
-  if (icon) {
-    icon = path.resolve(__dirname, '..', icon);
+  if (type === 'build') {
+    return icon;
   }
 
   if (icon && is.prod) {
     icon = icon.replace('app.asar', 'app.asar.unpacked');
   }
 
-  if (os === 'win' && !is.prod) {
+  if (process.platform === 'win32' && !is.prod) {
     return icon;
   }
 
-  if (os === 'linux') {
+  if (process.platform === 'linux') {
     return icon;
   }
 };

--- a/lib/icon.js
+++ b/lib/icon.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const is = require('./is.js');
+
+const osMap = {
+  win32: 'win',
+  darwin: 'mac',
+  linux: 'linux'
+};
+
+const iconMap = {
+  win: 'icons/icon.ico',
+  linux: 'icons/32x32.png',
+  mac: 'icons/icon.icns'
+};
+
+module.exports = () => {
+  const os = osMap[process.platform];
+  let icon = os ? path.resolve(__dirname, '..', iconMap[os]) : undefined;
+
+  if (icon) {
+    icon = path.resolve(__dirname, '..', icon);
+  }
+
+  if (icon && is.prod) {
+    icon = icon.replace('app.asar', 'app.asar.unpacked');
+  }
+
+  if (os === 'win' && !is.prod) {
+    return icon;
+  }
+
+  if (os === 'linux') {
+    return icon;
+  }
+};

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const events = new EventEmitter();
 const { app, BrowserWindow, ipcMain, systemPreferences } = require('electron');
 
 require('./lib/app-id.js')(app);
+const icon = require('./lib/icon.js');
 const log = require('./lib/log.js')('main');
 const config = require('./lib/config.js');
 const debounce = require('./lib/debounce.js');
@@ -58,6 +59,7 @@ function createWindow () {
         webviewTag: true,
         enableRemoteModule: true
       },
+      icon: icon(),
       frame: process.platform === 'darwin' ? true : !config.getProp('experiments.framelessWindow')
     };
 


### PR DESCRIPTION
#6 

This sets the icon during development, so that you see your icon on the application. This works everywhere except MacOS (you'll see the standard Electron icon there).

It also resolves the correct build time icon, so that built installers/apps show your icon. This works everywhere.